### PR TITLE
Add ardupilot and ardupilot_gz to our main image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,21 +18,21 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
 # Ardupilot
 RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && apt install -y default-jre socat \
-    && cd \
+    && cd /root \
     && git clone --recurse-submodules https://github.com/ardupilot/Micro-XRCE-DDS-Gen.git \
-    && cd Micro-XRCE-DDS-Gen \
+    && cd /root/Micro-XRCE-DDS-Gen \
     && ./gradlew assemble \
     && export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts \
     && echo "export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts" >> /root/.bashrc \
     && source /root/.bashrc \
-    && source /opt/ros/humble/setup.bash \
-    && cd \
+    && cd /root \
     && apt install -y python3-future python3-serial \
     && mkdir -p /root/catkin_ws/src \
     && cd /root/catkin_ws/src \
     && wget https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Tools/ros2/ros2.repos \
     && vcs import --recursive < ros2.repos \
-    && cd .. \
+    && cd /root/catkin_ws \
+    && source /opt/ros/humble/setup.bash \
     && apt update \
     && rosdep update \
     && rosdep install --rosdistro humble --from-paths src -r -y \
@@ -55,7 +55,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && vcs import --recursive < ros2_gz.repos \
     && export GZ_VERSION=garden \
     && echo "export GZ_VERSION=garden" >> /root/.bashrc \
-    && cd .. \
+    && cd /root/catkin_ws \
     && source /opt/ros/humble/setup.bash \
     && apt update \
     && rosdep update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && ./install_geographiclib_datasets.sh \
     && rm -rf install_geographiclib_datasets.sh
 
-# Install ardupilot
+# Install ardupilot and ardupilot_gz
 RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && apt upgrade -y \
     && apt install -y default-jre socat \
@@ -51,11 +51,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && . /opt/ros/humble/setup.sh \
     && colcon build \
     && export PATH=$PATH:/root/catkin_ws/src/ardupilot/Tools/autotest \
-    && echo "export PATH=$PATH:/root/catkin_ws/src/ardupilot/Tools/autotest" >> /root/.bashrc
-
-# Install ardupilot_gz
-RUN apt update && DEBIAN_FRONTEND=noninteractive \
-    && apt upgrade -y \
+    && echo "export PATH=$PATH:/root/catkin_ws/src/ardupilot/Tools/autotest" >> /root/.bashrc \
     && cd /root/catkin_ws/src \
     && wget https://raw.githubusercontent.com/ArduPilot/ardupilot_gz/main/ros2_gz.repos \
     && vcs import --recursive < ros2_gz.repos \
@@ -66,7 +62,8 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && rosdep update \
     && rosdep install --rosdistro humble --from-paths src -i -r -y \
     && . /opt/ros/humble/setup.sh \
-    && colcon build
+    && colcon build \
+    && sim_vehicle.py -w -v ArduCopter
 
 # Python deps
 # COPY ./requirements.txt requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,9 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && git clone --recurse-submodules https://github.com/ardupilot/Micro-XRCE-DDS-Gen.git \
     && cd Micro-XRCE-DDS-Gen \
     && ./gradlew assemble \
+    && export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts \
     && echo "export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts" >> /root/.bashrc \
-    && cd
-
-# Ardupilot
-RUN apt update && DEBIAN_FRONTEND=noninteractive \
+    && cd \
     && apt install -y python3-future python3-serial \
     && cd /root/catkin_ws/src \
     && wget https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Tools/ros2/ros2.repos \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,14 +26,14 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && cd Micro-XRCE-DDS-Gen \
     && ./gradlew assemble \
     && echo "export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts" >> /root/.bashrc \
-    && cd ~
+    && cd
 
 # Ardupilot
 RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && apt install -y python3-future python3-serial \
     && cd /root/catkin_ws/src \
     && wget https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Tools/ros2/ros2.repos \
-    && vcs import < ros2.repos \
+    && vcs import --recursive < ros2.repos \
     && cd .. \
     && rosdep update \
     && rosdep install --rosdistro ${ROS_DISTRO} --from-paths src -i -y \
@@ -66,6 +66,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y ros-humble-robot-localization
 
 # Install rtabmap
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y ros-humble-rtabmap-ros
 
 # Python deps
 # COPY ./requirements.txt requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM ros:humble-ros-base-jammy
 # Update and upgrade system.
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt upgrade -y
 
+# Python deps
+COPY ./requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
 # Gazebo Garden
 RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && apt upgrade -y \
@@ -64,10 +68,6 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && . /opt/ros/humble/setup.sh \
     && colcon build \
     && sim_vehicle.py -w -v ArduCopter
-
-# Python deps
-# COPY ./requirements.txt requirements.txt
-# RUN pip install -r requirements.txt
 
 # Configure environment
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y tmux htop vim

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Uses the ROS Humble as base image
-FROM osrf/ros:humble-ros-base-jammy
+FROM ros:humble-ros-base-jammy
 
 # Shell to be used during the build process and the container's default.
 SHELL ["/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,16 +35,17 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && wget https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Tools/ros2/ros2.repos \
     && vcs import < ros2.repos \
     && cd .. \
-    && source /opt/ros/humble/setup.bash \
     && rosdep update \
     && rosdep install --rosdistro ${ROS_DISTRO} --from-paths src -i -y \
-    && colcon build --cmake-args -DBUILD_TESTING=ON \
+    && source /opt/ros/humble/setup.bash \
+    && colcon build --cmake-args -DBUILD_TESTING=ON
 
 # Gazebo Garden
 RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && apt install -y install lsb-release wget gnupg \
     && wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" \
+    | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null \
     && apt install -y gz-garden
 
 # ardupilot_gz
@@ -55,10 +56,10 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && export GZ_VERSION=garden \
     && echo "export GZ_VERSION=garden" >> /root/.bashrc \
     && cd .. \
-    && source /opt/ros/humble/setup.bash \
     && apt update \
     && rosdep update \
     && rosdep install --rosdistro $ROS_DISTRO --from-paths src -i -r -y \
+    && source /opt/ros/humble/setup.bash \
     && colcon build --cmake-args -DBUILD_TESTING=ON
 
 # Install robot_localization
@@ -71,7 +72,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y ros-humble-robot
 # RUN pip install -r requirements.txt
 
 # Configure environment
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install tmux htop vim -y
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y tmux htop vim
 RUN echo 'source /opt/ros/humble/setup.bash' >> $HOME/.bashrc
 RUN echo 'source /usr/share/gazebo/setup.bash' >> $HOME/.bashrc
 RUN echo "set -g mouse on" >> /root/.tmux.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts \
     && echo "export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts" >> /root/.bashrc \
     && source /root/.bashrc \
+    && source /opt/ros/humble/setup.bash \
     && cd \
     && apt install -y python3-future python3-serial \
     && mkdir -p /root/catkin_ws/src \
@@ -34,9 +35,10 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && cd .. \
     && apt update \
     && rosdep update \
-    && rosdep install --rosdistro ${ROS_DISTRO} --from-paths src -i -y \
-    && source /opt/ros/humble/setup.bash \
-    && colcon build --cmake-args -DBUILD_TESTING=ON
+    && rosdep install --rosdistro ${ROS_DISTRO} --from-paths src -y \
+    && colcon build --cmake-args -DBUILD_TESTING=ON \
+    && export PATH=$PATH:/root/catkin_w/src/ardupilot/Tools/autotest \
+    && echo "export PATH=$PATH:/root/catkin_ws/src/ardupilot/Tools/autotest" >> /root/.bashrc
 
 # Gazebo Garden
 RUN apt update && DEBIAN_FRONTEND=noninteractive \
@@ -54,10 +56,10 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && export GZ_VERSION=garden \
     && echo "export GZ_VERSION=garden" >> /root/.bashrc \
     && cd .. \
+    && source /opt/ros/humble/setup.bash \
     && apt update \
     && rosdep update \
     && rosdep install --rosdistro $ROS_DISTRO --from-paths src -i -r -y \
-    && source /opt/ros/humble/setup.bash \
     && colcon build --cmake-args -DBUILD_TESTING=ON
 
 # Install robot_localization

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,6 @@ SHELL ["/bin/bash", "-c"]
 # Update and upgrade system.
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt upgrade -y
 
-# Create workspace
-RUN mkdir -p /root/catkin_ws/src
-
 # Install mavros and mavlink.
 RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && apt install -y ros-humble-rqt ros-humble-mavros ros-humble-mavros-extras ros-humble-mavros-msgs ros-humble-mavlink \
@@ -29,13 +26,16 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && echo "export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts" >> /root/.bashrc \
     && cd \
     && apt install -y python3-future python3-serial \
+    && mkdir -p /root/catkin_ws/src \
     && cd /root/catkin_ws/src \
     && wget https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Tools/ros2/ros2.repos \
     && vcs import --recursive < ros2.repos \
     && cd .. \
     && rosdep update \
+    && apt update \
     && rosdep install --rosdistro ${ROS_DISTRO} --from-paths src -i -y \
     && source /opt/ros/humble/setup.bash \
+    && source /root/.bashrc \
     && colcon build --cmake-args -DBUILD_TESTING=ON
 
 # Gazebo Garden
@@ -73,7 +73,6 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y ros-humble-rtabm
 # Configure environment
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y tmux htop vim
 RUN echo 'source /opt/ros/humble/setup.bash' >> $HOME/.bashrc
-RUN echo 'source /usr/share/gazebo/setup.bash' >> $HOME/.bashrc
 RUN echo "set -g mouse on" >> /root/.tmux.conf
 RUN echo "set-option -g history-limit 20000" >> /root/.tmux.conf
 RUN mkdir -p /root/catkin_ws/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && cd .. \
     && apt update \
     && rosdep update \
-    && rosdep install --rosdistro ${ROS_DISTRO} --from-paths src -y \
+    && rosdep install --rosdistro humble --from-paths src -r -y \
     && colcon build --cmake-args -DBUILD_TESTING=ON \
     && export PATH=$PATH:/root/catkin_w/src/ardupilot/Tools/autotest \
     && echo "export PATH=$PATH:/root/catkin_ws/src/ardupilot/Tools/autotest" >> /root/.bashrc
@@ -59,7 +59,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && source /opt/ros/humble/setup.bash \
     && apt update \
     && rosdep update \
-    && rosdep install --rosdistro $ROS_DISTRO --from-paths src -i -r -y \
+    && rosdep install --rosdistro humble --from-paths src -i -r -y \
     && colcon build --cmake-args -DBUILD_TESTING=ON
 
 # Install robot_localization

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && echo "export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts" >> /root/.bashrc \
     && cd /root \
     && apt install -y python3-future python3-serial python3-pip python-is-python3 gdb \
-    && pip install pexpect PyYAML mavproxy waftools pexpect --user \
+    && pip install pexpect PyYAML mavproxy waftools pexpect \
     && mkdir -p /root/catkin_ws/src \
     && cd /root/catkin_ws/src \
     && wget https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Tools/ros2/ros2.repos \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,16 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && ./install_geographiclib_datasets.sh \
     && rm -rf install_geographiclib_datasets.sh
 
-# Micro-XRCE-DDS-Gen
+# Ardupilot
 RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && apt install -y default-jre socat \
-    && cd ~ \
+    && cd \
     && git clone --recurse-submodules https://github.com/ardupilot/Micro-XRCE-DDS-Gen.git \
     && cd Micro-XRCE-DDS-Gen \
     && ./gradlew assemble \
     && export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts \
     && echo "export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts" >> /root/.bashrc \
+    && source /root/.bashrc \
     && cd \
     && apt install -y python3-future python3-serial \
     && mkdir -p /root/catkin_ws/src \
@@ -31,11 +32,10 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && wget https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Tools/ros2/ros2.repos \
     && vcs import --recursive < ros2.repos \
     && cd .. \
-    && rosdep update \
     && apt update \
+    && rosdep update \
     && rosdep install --rosdistro ${ROS_DISTRO} --from-paths src -i -y \
     && source /opt/ros/humble/setup.bash \
-    && source /root/.bashrc \
     && colcon build --cmake-args -DBUILD_TESTING=ON
 
 # Gazebo Garden

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y ros-humble-robot
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y ros-humble-gazebo-ros-pkgs ros-humble-gazebo-ros ros-humble-gazebo-plugins
 
 # Python deps
-COPY ./requirements.txt requirements.txt
-RUN pip install -r requirements.txt
+# COPY ./requirements.txt requirements.txt
+# RUN pip install -r requirements.txt
 
 # Configure environment
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install tmux htop vim -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 # Uses the ROS Humble as base image
-FROM osrf/ros:humble-desktop-full
+FROM osrf/ros:humble-ros-base-jammy
 
 # Shell to be used during the build process and the container's default.
 SHELL ["/bin/bash", "-c"]
 
-# Update the system.
-RUN apt update && apt upgrade -y
+# Update and upgrade system.
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt upgrade -y
+
+# Create workspace
+RUN mkdir -p /root/catkin_ws/src \
 
 # Install mavros and mavlink.
 RUN apt update && DEBIAN_FRONTEND=noninteractive \
@@ -15,11 +18,53 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && ./install_geographiclib_datasets.sh \
     && rm -rf install_geographiclib_datasets.sh
 
+# Micro-XRCE-DDS-Gen
+RUN apt update && DEBIAN_FRONTEND=noninteractive \
+    && apt install -y default-jre socat \
+    && cd ~ \
+    && git clone --recurse-submodules https://github.com/ardupilot/Micro-XRCE-DDS-Gen.git \
+    && cd Micro-XRCE-DDS-Gen \
+    && ./gradlew assemble \
+    && echo "export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts" >> /root/.bashrc \
+    && cd ~
+
+# Ardupilot
+RUN apt update && DEBIAN_FRONTEND=noninteractive \
+    && apt install -y python3-future python3-serial \
+    && cd /root/catkin_ws/src \
+    && wget https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Tools/ros2/ros2.repos \
+    && vcs import < ros2.repos \
+    && cd .. \
+    && rosdep update \
+    && rosdep install --rosdistro ${ROS_DISTRO} --from-paths src -i -y \
+    && colcon build --cmake-args -DBUILD_TESTING=ON \
+    && rm -rf /root/catkin_ws/src/ros2.repos
+
+# Gazebo Garden
+RUN apt update && DEBIAN_FRONTEND=noninteractive \
+    && apt install -y install lsb-release wget gnupg \
+    && wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null \
+    && apt install -y gz-garden
+
+# ardupilot_gz
+RUN apt update && DEBIAN_FRONTEND=noninteractive \
+    && cd /root/catkin_ws/src \
+    && wget https://raw.githubusercontent.com/ArduPilot/ardupilot_gz/main/ros2_gz.repos \
+    && vcs import --recursive < ros2_gz.repos \
+    && export GZ_VERSION=garden \
+    && echo "export GZ_VERSION=garden" >> /root/.bashrc \
+    && cd .. \
+    && source /opt/ros/humble/setup.bash \
+    && apt update \
+    && rosdep update \
+    && rosdep install --rosdistro $ROS_DISTRO --from-paths src -i -r -y \
+    && colcon build --cmake-args -DBUILD_TESTING=ON
+
 # Install robot_localization
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y ros-humble-robot-localization
 
-# Install Gazebo deps
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y ros-humble-gazebo-ros-pkgs ros-humble-gazebo-ros ros-humble-gazebo-plugins
+# Install rtabmap
 
 # Python deps
 # COPY ./requirements.txt requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-c"]
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt upgrade -y
 
 # Create workspace
-RUN mkdir -p /root/catkin_ws/src \
+RUN mkdir -p /root/catkin_ws/src
 
 # Install mavros and mavlink.
 RUN apt update && DEBIAN_FRONTEND=noninteractive \
@@ -35,10 +35,10 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && wget https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Tools/ros2/ros2.repos \
     && vcs import < ros2.repos \
     && cd .. \
+    && source /opt/ros/humble/setup.bash \
     && rosdep update \
     && rosdep install --rosdistro ${ROS_DISTRO} --from-paths src -i -y \
     && colcon build --cmake-args -DBUILD_TESTING=ON \
-    && rm -rf /root/catkin_ws/src/ros2.repos
 
 # Gazebo Garden
 RUN apt update && DEBIAN_FRONTEND=noninteractive \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts \
     && echo "export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts" >> /root/.bashrc \
     && cd /root \
-    && apt install -y python3-future python3-serial \
+    && apt install -y python3-future python3-serial python3-pip python-is-python3 gdb \
+    && pip install pexpect PyYAML mavproxy waftools pexpect --user \
     && mkdir -p /root/catkin_ws/src \
     && cd /root/catkin_ws/src \
     && wget https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Tools/ros2/ros2.repos \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,35 +15,6 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && ./install_geographiclib_datasets.sh \
     && rm -rf install_geographiclib_datasets.sh
 
-# Install ArduPilot
-RUN cd /root \
-    && apt install -y python3-dev python3-opencv python3-wxgtk4.0 python3-pip python3-matplotlib python3-lxml python3-pygame \
-    && git clone https://github.com/ufrj-nautilus/ardupilot.git \
-    && cd ardupilot \
-    && Tools/environment_install/install-prereqs-ubuntu.sh -y \
-    && git checkout $(git tag -l | grep Copter | tail -n1) \
-    && git submodule update --init --recursive \
-    && cd ArduCopter \
-    && pip3 install PyYAML mavproxy --user \
-    && usermod -a -G dialout root \
-    && echo 'export PATH=$PATH:/root/ardupilot/Tools/autotest' >> /root/.profile \
-    && echo 'export PATH=/usr/lib/ccache:$PATH' >> /root/.profile \
-    && echo 'export PYTHONPATH=:/usr/local/lib/python3.8/dist-packages:$PYTHONPATH' >> /root/.profile \
-    && echo 'export PATH=/root/.local/bin:$PATH' >> /root/.profile \
-    && . /root/.profile \
-    && python3 ../Tools/autotest/sim_vehicle.py -w
-
-# Install ardupilot_gazebo
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y libignition-gazebo6-dev rapidjson-dev \
-    && cd $HOME \
-    && git clone https://github.com/ArduPilot/ardupilot_gazebo -b fortress \
-    && cd ardupilot_gazebo \
-    && mkdir build && cd build \
-    && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-    && make -j4 \
-    && echo 'export IGN_GAZEBO_SYSTEM_PLUGIN_PATH=$HOME/ardupilot_gazebo/build:${IGN_GAZEBO_SYSTEM_PLUGIN_PATH}' >> ~/.bashrc \
-    && echo 'export IGN_GAZEBO_RESOURCE_PATH=$HOME/ardupilot_gazebo/models:$HOME/ardupilot_gazebo/worlds:${IGN_GAZEBO_RESOURCE_PATH}' >> ~/.bashrc
-
 # Install robot_localization
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y ros-humble-robot-localization
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,66 +1,17 @@
 # Uses the ROS Humble as base image
 FROM ros:humble-ros-base-jammy
 
-# Shell to be used during the build process and the container's default.
-SHELL ["/bin/bash", "-c"]
-
 # Update and upgrade system.
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt upgrade -y
 
-# Install mavros and mavlink.
-RUN apt update && DEBIAN_FRONTEND=noninteractive \
-    && apt install -y ros-humble-rqt ros-humble-mavros ros-humble-mavros-extras ros-humble-mavros-msgs ros-humble-mavlink \
-    && wget https://raw.githubusercontent.com/mavlink/mavros/ros2/mavros/scripts/install_geographiclib_datasets.sh \
-    && chmod +x install_geographiclib_datasets.sh \
-    && ./install_geographiclib_datasets.sh \
-    && rm -rf install_geographiclib_datasets.sh
-
-# Ardupilot
-RUN apt update && DEBIAN_FRONTEND=noninteractive \
-    && apt install -y default-jre socat \
-    && cd /root \
-    && git clone --recurse-submodules https://github.com/ardupilot/Micro-XRCE-DDS-Gen.git \
-    && cd /root/Micro-XRCE-DDS-Gen \
-    && ./gradlew assemble \
-    && export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts \
-    && echo "export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts" >> /root/.bashrc \
-    && source /root/.bashrc \
-    && cd /root \
-    && apt install -y python3-future python3-serial \
-    && mkdir -p /root/catkin_ws/src \
-    && cd /root/catkin_ws/src \
-    && wget https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Tools/ros2/ros2.repos \
-    && vcs import --recursive < ros2.repos \
-    && cd /root/catkin_ws \
-    && source /opt/ros/humble/setup.bash \
-    && apt update \
-    && rosdep update \
-    && rosdep install --rosdistro humble --from-paths src -r -y \
-    && colcon build --cmake-args -DBUILD_TESTING=ON \
-    && export PATH=$PATH:/root/catkin_w/src/ardupilot/Tools/autotest \
-    && echo "export PATH=$PATH:/root/catkin_ws/src/ardupilot/Tools/autotest" >> /root/.bashrc
-
 # Gazebo Garden
 RUN apt update && DEBIAN_FRONTEND=noninteractive \
-    && apt install -y install lsb-release wget gnupg \
+    && apt upgrade -y \
+    && apt install -y lsb-release wget gnupg \
     && wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" \
-    | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null \
-    && apt install -y gz-garden
-
-# ardupilot_gz
-RUN apt update && DEBIAN_FRONTEND=noninteractive \
-    && cd /root/catkin_ws/src \
-    && wget https://raw.githubusercontent.com/ArduPilot/ardupilot_gz/main/ros2_gz.repos \
-    && vcs import --recursive < ros2_gz.repos \
-    && export GZ_VERSION=garden \
-    && echo "export GZ_VERSION=garden" >> /root/.bashrc \
-    && cd /root/catkin_ws \
-    && source /opt/ros/humble/setup.bash \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null \
     && apt update \
-    && rosdep update \
-    && rosdep install --rosdistro humble --from-paths src -i -r -y \
-    && colcon build --cmake-args -DBUILD_TESTING=ON
+    && apt install -y gz-garden
 
 # Install robot_localization
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y ros-humble-robot-localization
@@ -68,13 +19,62 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y ros-humble-robot
 # Install rtabmap
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y ros-humble-rtabmap-ros
 
+# Install mavros and mavlink.
+RUN apt update && DEBIAN_FRONTEND=noninteractive \
+    && apt upgrade -y \
+    && apt install -y ros-humble-rqt ros-humble-mavros ros-humble-mavros-extras ros-humble-mavros-msgs ros-humble-mavlink \
+    && wget https://raw.githubusercontent.com/mavlink/mavros/ros2/mavros/scripts/install_geographiclib_datasets.sh \
+    && chmod +x install_geographiclib_datasets.sh \
+    && ./install_geographiclib_datasets.sh \
+    && rm -rf install_geographiclib_datasets.sh
+
+# Install ardupilot
+RUN apt update && DEBIAN_FRONTEND=noninteractive \
+    && apt upgrade -y \
+    && apt install -y default-jre socat \
+    && cd /root \
+    && git clone --recurse-submodules https://github.com/ardupilot/Micro-XRCE-DDS-Gen.git \
+    && cd /root/Micro-XRCE-DDS-Gen \
+    && ./gradlew assemble \
+    && export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts \
+    && echo "export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts" >> /root/.bashrc \
+    && cd /root \
+    && apt install -y python3-future python3-serial \
+    && mkdir -p /root/catkin_ws/src \
+    && cd /root/catkin_ws/src \
+    && wget https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Tools/ros2/ros2.repos \
+    && vcs import --recursive < ros2.repos \
+    && cd /root/catkin_ws \
+    && rosdep update \
+    && rosdep install --rosdistro humble --from-paths src -i -r -y \
+    && . /opt/ros/humble/setup.sh \
+    && colcon build \
+    && export PATH=$PATH:/root/catkin_ws/src/ardupilot/Tools/autotest \
+    && echo "export PATH=$PATH:/root/catkin_ws/src/ardupilot/Tools/autotest" >> /root/.bashrc
+
+# Install ardupilot_gz
+RUN apt update && DEBIAN_FRONTEND=noninteractive \
+    && apt upgrade -y \
+    && cd /root/catkin_ws/src \
+    && wget https://raw.githubusercontent.com/ArduPilot/ardupilot_gz/main/ros2_gz.repos \
+    && vcs import --recursive < ros2_gz.repos \
+    && export GZ_VERSION=garden \
+    && echo "export GZ_VERSION=garden" >> /root/.bashrc \
+    && cd /root/catkin_ws \
+    && apt update \
+    && rosdep update \
+    && rosdep install --rosdistro humble --from-paths src -i -r -y \
+    && . /opt/ros/humble/setup.sh \
+    && colcon build
+
 # Python deps
 # COPY ./requirements.txt requirements.txt
 # RUN pip install -r requirements.txt
 
 # Configure environment
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y tmux htop vim
-RUN echo 'source /opt/ros/humble/setup.bash' >> $HOME/.bashrc
+RUN echo 'source /opt/ros/humble/setup.bash' >> root/.bashrc
+RUN echo 'source /root/catkin_ws/install/setup.bash' >> root/.bashrc
 RUN echo "set -g mouse on" >> /root/.tmux.conf
 RUN echo "set-option -g history-limit 20000" >> /root/.tmux.conf
 RUN mkdir -p /root/catkin_ws/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 # Uses the ROS Humble as base image
 FROM ros:humble-ros-base-jammy
 
+# Shell to be used during the build process and the container's default.
+SHELL ["/bin/bash", "-c"]
+
 # Update and upgrade system.
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt upgrade -y
 
 # Python deps
 COPY ./requirements.txt requirements.txt
-RUN pip install -r requirements.txt
+RUN apt update && DEBIAN_FRONTEND=noninteractive \
+    && apt install -y python3-pip \
+    && pip install -r requirements.txt
 
 # Gazebo Garden
 RUN apt update && DEBIAN_FRONTEND=noninteractive \
@@ -43,7 +48,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts \
     && echo "export PATH=$PATH:/root/Micro-XRCE-DDS-Gen/scripts" >> /root/.bashrc \
     && cd /root \
-    && apt install -y python3-future python3-serial python3-pip python-is-python3 gdb \
+    && apt install -y python3-future python3-serial python-is-python3 gdb \
     && pip install pexpect PyYAML mavproxy waftools pexpect \
     && mkdir -p /root/catkin_ws/src \
     && cd /root/catkin_ws/src \
@@ -52,7 +57,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && cd /root/catkin_ws \
     && rosdep update \
     && rosdep install --rosdistro humble --from-paths src -i -r -y \
-    && . /opt/ros/humble/setup.sh \
+    && source /opt/ros/humble/setup.sh \
     && colcon build \
     && export PATH=$PATH:/root/catkin_ws/src/ardupilot/Tools/autotest \
     && echo "export PATH=$PATH:/root/catkin_ws/src/ardupilot/Tools/autotest" >> /root/.bashrc \
@@ -65,7 +70,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     && apt update \
     && rosdep update \
     && rosdep install --rosdistro humble --from-paths src -i -r -y \
-    && . /opt/ros/humble/setup.sh \
+    && source /opt/ros/humble/setup.sh \
     && colcon build \
     && sim_vehicle.py -w -v ArduCopter
 


### PR DESCRIPTION
# Description

- Before this PR, we didn't had ardupilot and ardupilot_gz, the last one, the package that integrates with gazebo for simulation, properly setup.
- This PR only install ardupilot and ardupilot_gz with all of it's dependencies.

# Other changes

- Moved from gazebo 11 to gazebo garden, hard dependency of ardupilot_gz

# References

[Mavros and Mavlink (we already had that)](https://ardupilot.org/dev/docs/ros-install.html#installing-mavros)
[Intgration with SITL (using ardupilot in simulation instead of actual pixhawk)](https://ardupilot.org/dev/docs/ros2-sitl.html)
[Gazebo integration](https://ardupilot.org/dev/docs/ros2-gazebo.html)